### PR TITLE
bin/kasten should return a json

### DIFF
--- a/bin/kasten
+++ b/bin/kasten
@@ -1,3 +1,5 @@
 #!/usr/bin/env ruby
+require 'kasten'
+require 'json'
 
-require "kasten"
+puts Kasten.kasten.to_json


### PR DESCRIPTION
To be used in shell scripts.

```
$ kasten 
{"x":235,"y":286,"w":278,"h":199}
```
